### PR TITLE
feat(Auto Content): Adding generated MCQ to quizzes

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "5.10.2",
-	"lastUpdateCheck": 1739731438293,
-	"lastNotification": 1739224777078
+	"latest": "5.10.4",
+	"lastUpdateCheck": 1740969502770,
+	"lastNotification": 1740969502760
 }

--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "5.10.0",
-	"lastUpdateCheck": 1739388492770,
+	"latest": "5.10.2",
+	"lastUpdateCheck": 1739731438293,
 	"lastNotification": 1739224777078
 }

--- a/src/api/quiz/content-types/quiz/schema.json
+++ b/src/api/quiz/content-types/quiz/schema.json
@@ -21,7 +21,8 @@
     "Questions": {
       "type": "dynamiczone",
       "components": [
-        "quizzes.multiple-choice-question"
+        "quizzes.multiple-choice-question",
+        "quizzes.generated-mcq"
       ]
     },
     "QuizType": {
@@ -32,6 +33,14 @@
       ],
       "default": "Open Book",
       "required": true
+    },
+    "AssociatedChapter": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::chapter.chapter"
+    },
+    "Identifier": {
+      "type": "uid"
     }
   }
 }

--- a/src/components/quizzes/generated-mcq.json
+++ b/src/components/quizzes/generated-mcq.json
@@ -1,0 +1,13 @@
+{
+  "collectionName": "components_quizzes_generated_mcqs",
+  "info": {
+    "displayName": "GeneratedMCQ"
+  },
+  "options": {},
+  "attributes": {
+    "GeneratedQuestion": {
+      "type": "customField",
+      "customField": "plugin::auto-content.mcqGenerator"
+    }
+  }
+}

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-02-12T19:28:33.528Z"
+    "x-generation-date": "2025-02-17T05:35:27.963Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -5709,13 +5709,17 @@
                         "anyOf": [
                           {
                             "$ref": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                          },
+                          {
+                            "$ref": "#/components/schemas/QuizzesGeneratedMcqComponent"
                           }
                         ]
                       },
                       "discriminator": {
                         "propertyName": "__component",
                         "mapping": {
-                          "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                          "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent",
+                          "quizzes.generated-mcq": "#/components/schemas/QuizzesGeneratedMcqComponent"
                         }
                       }
                     },
@@ -5726,19 +5730,7 @@
                         "Closed Book"
                       ]
                     },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "publishedAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "createdBy": {
+                    "AssociatedChapter": {
                       "type": "object",
                       "properties": {
                         "id": {
@@ -5747,29 +5739,7 @@
                         "documentId": {
                           "type": "string"
                         },
-                        "firstname": {
-                          "type": "string"
-                        },
-                        "lastname": {
-                          "type": "string"
-                        },
-                        "username": {
-                          "type": "string"
-                        },
-                        "email": {
-                          "type": "string",
-                          "format": "email"
-                        },
-                        "resetPasswordToken": {
-                          "type": "string"
-                        },
-                        "registrationToken": {
-                          "type": "string"
-                        },
-                        "isActive": {
-                          "type": "boolean"
-                        },
-                        "roles": {
+                        "Pages": {
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -5779,33 +5749,124 @@
                               },
                               "documentId": {
                                 "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "code": {
-                                "type": "string"
-                              },
-                              "description": {
-                                "type": "string"
-                              },
-                              "users": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "id": {
-                                      "type": "number"
-                                    },
-                                    "documentId": {
-                                      "type": "string"
-                                    }
+                              }
+                            }
+                          }
+                        },
+                        "Title": {
+                          "type": "string"
+                        },
+                        "Module": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "number"
+                            },
+                            "documentId": {
+                              "type": "string"
+                            },
+                            "Title": {
+                              "type": "string"
+                            },
+                            "Slug": {
+                              "type": "string"
+                            },
+                            "Chapters": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number"
+                                  },
+                                  "documentId": {
+                                    "type": "string"
                                   }
                                 }
-                              },
-                              "permissions": {
-                                "type": "array",
-                                "items": {
+                              }
+                            },
+                            "Volume": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "number"
+                                },
+                                "documentId": {
+                                  "type": "string"
+                                },
+                                "Title": {
+                                  "type": "string"
+                                },
+                                "Owner": {
+                                  "type": "string"
+                                },
+                                "Description": {
+                                  "type": "string"
+                                },
+                                "Slug": {
+                                  "type": "string"
+                                },
+                                "Chapters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "number"
+                                      },
+                                      "documentId": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "Modules": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "number"
+                                      },
+                                      "documentId": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "Pages": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "number"
+                                      },
+                                      "documentId": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VolumeSummary": {
+                                  "type": "string"
+                                },
+                                "FreePages": {
+                                  "type": "string"
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "publishedAt": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "createdBy": {
                                   "type": "object",
                                   "properties": {
                                     "id": {
@@ -5814,25 +5875,206 @@
                                     "documentId": {
                                       "type": "string"
                                     },
-                                    "action": {
+                                    "firstname": {
                                       "type": "string"
                                     },
-                                    "actionParameters": {},
-                                    "subject": {
+                                    "lastname": {
                                       "type": "string"
                                     },
-                                    "properties": {},
-                                    "conditions": {},
-                                    "role": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": "number"
-                                        },
-                                        "documentId": {
-                                          "type": "string"
+                                    "username": {
+                                      "type": "string"
+                                    },
+                                    "email": {
+                                      "type": "string",
+                                      "format": "email"
+                                    },
+                                    "resetPasswordToken": {
+                                      "type": "string"
+                                    },
+                                    "registrationToken": {
+                                      "type": "string"
+                                    },
+                                    "isActive": {
+                                      "type": "boolean"
+                                    },
+                                    "roles": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "number"
+                                          },
+                                          "documentId": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": "string"
+                                          },
+                                          "users": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "number"
+                                                },
+                                                "documentId": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "permissions": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "number"
+                                                },
+                                                "documentId": {
+                                                  "type": "string"
+                                                },
+                                                "action": {
+                                                  "type": "string"
+                                                },
+                                                "actionParameters": {},
+                                                "subject": {
+                                                  "type": "string"
+                                                },
+                                                "properties": {},
+                                                "conditions": {},
+                                                "role": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "number"
+                                                    },
+                                                    "documentId": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "createdAt": {
+                                                  "type": "string",
+                                                  "format": "date-time"
+                                                },
+                                                "updatedAt": {
+                                                  "type": "string",
+                                                  "format": "date-time"
+                                                },
+                                                "publishedAt": {
+                                                  "type": "string",
+                                                  "format": "date-time"
+                                                },
+                                                "createdBy": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "number"
+                                                    },
+                                                    "documentId": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "updatedBy": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "number"
+                                                    },
+                                                    "documentId": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "locale": {
+                                                  "type": "string"
+                                                },
+                                                "localizations": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "id": {
+                                                        "type": "number"
+                                                      },
+                                                      "documentId": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "createdAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "updatedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "publishedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "createdBy": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "number"
+                                              },
+                                              "documentId": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "updatedBy": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "number"
+                                              },
+                                              "documentId": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "locale": {
+                                            "type": "string"
+                                          },
+                                          "localizations": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "number"
+                                                },
+                                                "documentId": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
                                         }
                                       }
+                                    },
+                                    "blocked": {
+                                      "type": "boolean"
+                                    },
+                                    "preferedLanguage": {
+                                      "type": "string"
                                     },
                                     "createdAt": {
                                       "type": "string",
@@ -5886,48 +6128,8 @@
                                       }
                                     }
                                   }
-                                }
-                              },
-                              "createdAt": {
-                                "type": "string",
-                                "format": "date-time"
-                              },
-                              "updatedAt": {
-                                "type": "string",
-                                "format": "date-time"
-                              },
-                              "publishedAt": {
-                                "type": "string",
-                                "format": "date-time"
-                              },
-                              "createdBy": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "number"
-                                  },
-                                  "documentId": {
-                                    "type": "string"
-                                  }
-                                }
-                              },
-                              "updatedBy": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "number"
-                                  },
-                                  "documentId": {
-                                    "type": "string"
-                                  }
-                                }
-                              },
-                              "locale": {
-                                "type": "string"
-                              },
-                              "localizations": {
-                                "type": "array",
-                                "items": {
+                                },
+                                "updatedBy": {
                                   "type": "object",
                                   "properties": {
                                     "id": {
@@ -5937,226 +6139,25 @@
                                       "type": "string"
                                     }
                                   }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "blocked": {
-                          "type": "boolean"
-                        },
-                        "preferedLanguage": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        "publishedAt": {
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        "createdBy": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "number"
-                            },
-                            "documentId": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "updatedBy": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "number"
-                            },
-                            "documentId": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "locale": {
-                          "type": "string"
-                        },
-                        "localizations": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "number"
-                              },
-                              "documentId": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "updatedBy": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "number"
-                        },
-                        "documentId": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "locale": {
-                      "type": "string"
-                    },
-                    "localizations": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "number"
-                          },
-                          "documentId": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "ReferenceSummary": {
-                  "type": "string"
-                },
-                "Chapter": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "documentId": {
-                      "type": "string"
-                    },
-                    "Pages": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "number"
-                          },
-                          "documentId": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    },
-                    "Title": {
-                      "type": "string"
-                    },
-                    "Module": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "number"
-                        },
-                        "documentId": {
-                          "type": "string"
-                        },
-                        "Title": {
-                          "type": "string"
-                        },
-                        "Slug": {
-                          "type": "string"
-                        },
-                        "Chapters": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "number"
-                              },
-                              "documentId": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "Volume": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "number"
-                            },
-                            "documentId": {
-                              "type": "string"
-                            },
-                            "Title": {
-                              "type": "string"
-                            },
-                            "Owner": {
-                              "type": "string"
-                            },
-                            "Description": {
-                              "type": "string"
-                            },
-                            "Slug": {
-                              "type": "string"
-                            },
-                            "Chapters": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "number"
-                                  },
-                                  "documentId": {
-                                    "type": "string"
+                                },
+                                "locale": {
+                                  "type": "string"
+                                },
+                                "localizations": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "number"
+                                      },
+                                      "documentId": {
+                                        "type": "string"
+                                      }
+                                    }
                                   }
                                 }
                               }
-                            },
-                            "Modules": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "number"
-                                  },
-                                  "documentId": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            },
-                            "Pages": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "number"
-                                  },
-                                  "documentId": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            },
-                            "VolumeSummary": {
-                              "type": "string"
-                            },
-                            "FreePages": {
-                              "type": "string"
                             },
                             "createdAt": {
                               "type": "string",
@@ -6211,6 +6212,23 @@
                             }
                           }
                         },
+                        "Slug": {
+                          "type": "string"
+                        },
+                        "ChapterNumber": {
+                          "type": "integer"
+                        },
+                        "Volume": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "number"
+                            },
+                            "documentId": {
+                              "type": "string"
+                            }
+                          }
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time"
@@ -6264,22 +6282,8 @@
                         }
                       }
                     },
-                    "Slug": {
+                    "Identifier": {
                       "type": "string"
-                    },
-                    "ChapterNumber": {
-                      "type": "integer"
-                    },
-                    "Volume": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "number"
-                        },
-                        "documentId": {
-                          "type": "string"
-                        }
-                      }
                     },
                     "createdAt": {
                       "type": "string",
@@ -6331,6 +6335,20 @@
                           }
                         }
                       }
+                    }
+                  }
+                },
+                "ReferenceSummary": {
+                  "type": "string"
+                },
+                "Chapter": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
                     }
                   }
                 },
@@ -6685,6 +6703,23 @@
             "items": {
               "$ref": "#/components/schemas/QuizzesMultipleChoiceOptionComponent"
             }
+          }
+        }
+      },
+      "QuizzesGeneratedMcqComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "__component": {
+            "type": "string",
+            "enum": [
+              "quizzes.generated-mcq"
+            ]
+          },
+          "GeneratedQuestion": {
+            "type": "string"
           }
         }
       },
@@ -7348,13 +7383,17 @@
                               "anyOf": [
                                 {
                                   "$ref": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                                },
+                                {
+                                  "$ref": "#/components/schemas/QuizzesGeneratedMcqComponent"
                                 }
                               ]
                             },
                             "discriminator": {
                               "propertyName": "__component",
                               "mapping": {
-                                "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                                "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent",
+                                "quizzes.generated-mcq": "#/components/schemas/QuizzesGeneratedMcqComponent"
                               }
                             }
                           },
@@ -7364,6 +7403,20 @@
                               "Open Book",
                               "Closed Book"
                             ]
+                          },
+                          "AssociatedChapter": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "documentId": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "Identifier": {
+                            "type": "string"
                           },
                           "createdAt": {
                             "type": "string",
@@ -8993,13 +9046,17 @@
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/QuizzesGeneratedMcqComponent"
                     }
                   ]
                 },
                 "discriminator": {
                   "propertyName": "__component",
                   "mapping": {
-                    "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                    "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent",
+                    "quizzes.generated-mcq": "#/components/schemas/QuizzesGeneratedMcqComponent"
                   }
                 }
               },
@@ -9009,6 +9066,20 @@
                   "Open Book",
                   "Closed Book"
                 ]
+              },
+              "AssociatedChapter": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "Identifier": {
+                "type": "string"
               },
               "createdAt": {
                 "type": "string",
@@ -9187,13 +9258,17 @@
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/QuizzesGeneratedMcqComponent"
                     }
                   ]
                 },
                 "discriminator": {
                   "propertyName": "__component",
                   "mapping": {
-                    "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                    "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent",
+                    "quizzes.generated-mcq": "#/components/schemas/QuizzesGeneratedMcqComponent"
                   }
                 }
               },
@@ -9203,6 +9278,20 @@
                   "Open Book",
                   "Closed Book"
                 ]
+              },
+              "AssociatedChapter": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "example": "string or id"
+              },
+              "Identifier": {
+                "type": "string"
               },
               "locale": {
                 "type": "string"
@@ -9340,13 +9429,17 @@
                       "anyOf": [
                         {
                           "$ref": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                        },
+                        {
+                          "$ref": "#/components/schemas/QuizzesGeneratedMcqComponent"
                         }
                       ]
                     },
                     "discriminator": {
                       "propertyName": "__component",
                       "mapping": {
-                        "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                        "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent",
+                        "quizzes.generated-mcq": "#/components/schemas/QuizzesGeneratedMcqComponent"
                       }
                     }
                   },
@@ -9357,19 +9450,7 @@
                       "Closed Book"
                     ]
                   },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "updatedAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "publishedAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "createdBy": {
+                  "AssociatedChapter": {
                     "type": "object",
                     "properties": {
                       "id": {
@@ -9378,29 +9459,7 @@
                       "documentId": {
                         "type": "string"
                       },
-                      "firstname": {
-                        "type": "string"
-                      },
-                      "lastname": {
-                        "type": "string"
-                      },
-                      "username": {
-                        "type": "string"
-                      },
-                      "email": {
-                        "type": "string",
-                        "format": "email"
-                      },
-                      "resetPasswordToken": {
-                        "type": "string"
-                      },
-                      "registrationToken": {
-                        "type": "string"
-                      },
-                      "isActive": {
-                        "type": "boolean"
-                      },
-                      "roles": {
+                      "Pages": {
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -9410,33 +9469,124 @@
                             },
                             "documentId": {
                               "type": "string"
-                            },
-                            "name": {
-                              "type": "string"
-                            },
-                            "code": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            },
-                            "users": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "number"
-                                  },
-                                  "documentId": {
-                                    "type": "string"
-                                  }
+                            }
+                          }
+                        }
+                      },
+                      "Title": {
+                        "type": "string"
+                      },
+                      "Module": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "documentId": {
+                            "type": "string"
+                          },
+                          "Title": {
+                            "type": "string"
+                          },
+                          "Slug": {
+                            "type": "string"
+                          },
+                          "Chapters": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "number"
+                                },
+                                "documentId": {
+                                  "type": "string"
                                 }
                               }
-                            },
-                            "permissions": {
-                              "type": "array",
-                              "items": {
+                            }
+                          },
+                          "Volume": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "documentId": {
+                                "type": "string"
+                              },
+                              "Title": {
+                                "type": "string"
+                              },
+                              "Owner": {
+                                "type": "string"
+                              },
+                              "Description": {
+                                "type": "string"
+                              },
+                              "Slug": {
+                                "type": "string"
+                              },
+                              "Chapters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "number"
+                                    },
+                                    "documentId": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "Modules": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "number"
+                                    },
+                                    "documentId": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "Pages": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "number"
+                                    },
+                                    "documentId": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "VolumeSummary": {
+                                "type": "string"
+                              },
+                              "FreePages": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "publishedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "createdBy": {
                                 "type": "object",
                                 "properties": {
                                   "id": {
@@ -9445,25 +9595,206 @@
                                   "documentId": {
                                     "type": "string"
                                   },
-                                  "action": {
+                                  "firstname": {
                                     "type": "string"
                                   },
-                                  "actionParameters": {},
-                                  "subject": {
+                                  "lastname": {
                                     "type": "string"
                                   },
-                                  "properties": {},
-                                  "conditions": {},
-                                  "role": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "number"
-                                      },
-                                      "documentId": {
-                                        "type": "string"
+                                  "username": {
+                                    "type": "string"
+                                  },
+                                  "email": {
+                                    "type": "string",
+                                    "format": "email"
+                                  },
+                                  "resetPasswordToken": {
+                                    "type": "string"
+                                  },
+                                  "registrationToken": {
+                                    "type": "string"
+                                  },
+                                  "isActive": {
+                                    "type": "boolean"
+                                  },
+                                  "roles": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "number"
+                                        },
+                                        "documentId": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": "string"
+                                        },
+                                        "users": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "number"
+                                              },
+                                              "documentId": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "permissions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "number"
+                                              },
+                                              "documentId": {
+                                                "type": "string"
+                                              },
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "actionParameters": {},
+                                              "subject": {
+                                                "type": "string"
+                                              },
+                                              "properties": {},
+                                              "conditions": {},
+                                              "role": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "number"
+                                                  },
+                                                  "documentId": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "createdAt": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                              },
+                                              "updatedAt": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                              },
+                                              "publishedAt": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                              },
+                                              "createdBy": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "number"
+                                                  },
+                                                  "documentId": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "updatedBy": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "number"
+                                                  },
+                                                  "documentId": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "locale": {
+                                                "type": "string"
+                                              },
+                                              "localizations": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "number"
+                                                    },
+                                                    "documentId": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "createdAt": {
+                                          "type": "string",
+                                          "format": "date-time"
+                                        },
+                                        "updatedAt": {
+                                          "type": "string",
+                                          "format": "date-time"
+                                        },
+                                        "publishedAt": {
+                                          "type": "string",
+                                          "format": "date-time"
+                                        },
+                                        "createdBy": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "number"
+                                            },
+                                            "documentId": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "updatedBy": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "number"
+                                            },
+                                            "documentId": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "locale": {
+                                          "type": "string"
+                                        },
+                                        "localizations": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "number"
+                                              },
+                                              "documentId": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
                                       }
                                     }
+                                  },
+                                  "blocked": {
+                                    "type": "boolean"
+                                  },
+                                  "preferedLanguage": {
+                                    "type": "string"
                                   },
                                   "createdAt": {
                                     "type": "string",
@@ -9517,48 +9848,8 @@
                                     }
                                   }
                                 }
-                              }
-                            },
-                            "createdAt": {
-                              "type": "string",
-                              "format": "date-time"
-                            },
-                            "updatedAt": {
-                              "type": "string",
-                              "format": "date-time"
-                            },
-                            "publishedAt": {
-                              "type": "string",
-                              "format": "date-time"
-                            },
-                            "createdBy": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "number"
-                                },
-                                "documentId": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "updatedBy": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "number"
-                                },
-                                "documentId": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "locale": {
-                              "type": "string"
-                            },
-                            "localizations": {
-                              "type": "array",
-                              "items": {
+                              },
+                              "updatedBy": {
                                 "type": "object",
                                 "properties": {
                                   "id": {
@@ -9568,226 +9859,25 @@
                                     "type": "string"
                                   }
                                 }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "blocked": {
-                        "type": "boolean"
-                      },
-                      "preferedLanguage": {
-                        "type": "string"
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "publishedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "createdBy": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "number"
-                          },
-                          "documentId": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "updatedBy": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "number"
-                          },
-                          "documentId": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "locale": {
-                        "type": "string"
-                      },
-                      "localizations": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "number"
-                            },
-                            "documentId": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "updatedBy": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "number"
-                      },
-                      "documentId": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "locale": {
-                    "type": "string"
-                  },
-                  "localizations": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "number"
-                        },
-                        "documentId": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "ReferenceSummary": {
-                "type": "string"
-              },
-              "Chapter": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "number"
-                  },
-                  "documentId": {
-                    "type": "string"
-                  },
-                  "Pages": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "number"
-                        },
-                        "documentId": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "Title": {
-                    "type": "string"
-                  },
-                  "Module": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "number"
-                      },
-                      "documentId": {
-                        "type": "string"
-                      },
-                      "Title": {
-                        "type": "string"
-                      },
-                      "Slug": {
-                        "type": "string"
-                      },
-                      "Chapters": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "number"
-                            },
-                            "documentId": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "Volume": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "number"
-                          },
-                          "documentId": {
-                            "type": "string"
-                          },
-                          "Title": {
-                            "type": "string"
-                          },
-                          "Owner": {
-                            "type": "string"
-                          },
-                          "Description": {
-                            "type": "string"
-                          },
-                          "Slug": {
-                            "type": "string"
-                          },
-                          "Chapters": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "number"
-                                },
-                                "documentId": {
-                                  "type": "string"
+                              },
+                              "locale": {
+                                "type": "string"
+                              },
+                              "localizations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "number"
+                                    },
+                                    "documentId": {
+                                      "type": "string"
+                                    }
+                                  }
                                 }
                               }
                             }
-                          },
-                          "Modules": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "number"
-                                },
-                                "documentId": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          },
-                          "Pages": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "number"
-                                },
-                                "documentId": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          },
-                          "VolumeSummary": {
-                            "type": "string"
-                          },
-                          "FreePages": {
-                            "type": "string"
                           },
                           "createdAt": {
                             "type": "string",
@@ -9842,6 +9932,23 @@
                           }
                         }
                       },
+                      "Slug": {
+                        "type": "string"
+                      },
+                      "ChapterNumber": {
+                        "type": "integer"
+                      },
+                      "Volume": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "documentId": {
+                            "type": "string"
+                          }
+                        }
+                      },
                       "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -9895,22 +10002,8 @@
                       }
                     }
                   },
-                  "Slug": {
+                  "Identifier": {
                     "type": "string"
-                  },
-                  "ChapterNumber": {
-                    "type": "integer"
-                  },
-                  "Volume": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "number"
-                      },
-                      "documentId": {
-                        "type": "string"
-                      }
-                    }
                   },
                   "createdAt": {
                     "type": "string",
@@ -9962,6 +10055,20 @@
                         }
                       }
                     }
+                  }
+                }
+              },
+              "ReferenceSummary": {
+                "type": "string"
+              },
+              "Chapter": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
                   }
                 }
               },
@@ -10041,13 +10148,17 @@
               "anyOf": [
                 {
                   "$ref": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                },
+                {
+                  "$ref": "#/components/schemas/QuizzesGeneratedMcqComponent"
                 }
               ]
             },
             "discriminator": {
               "propertyName": "__component",
               "mapping": {
-                "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent",
+                "quizzes.generated-mcq": "#/components/schemas/QuizzesGeneratedMcqComponent"
               }
             }
           },
@@ -10057,6 +10168,20 @@
               "Open Book",
               "Closed Book"
             ]
+          },
+          "AssociatedChapter": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "documentId": {
+                "type": "string"
+              }
+            }
+          },
+          "Identifier": {
+            "type": "string"
           },
           "createdAt": {
             "type": "string",
@@ -10355,13 +10480,17 @@
                               "anyOf": [
                                 {
                                   "$ref": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                                },
+                                {
+                                  "$ref": "#/components/schemas/QuizzesGeneratedMcqComponent"
                                 }
                               ]
                             },
                             "discriminator": {
                               "propertyName": "__component",
                               "mapping": {
-                                "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent"
+                                "quizzes.multiple-choice-question": "#/components/schemas/QuizzesMultipleChoiceQuestionComponent",
+                                "quizzes.generated-mcq": "#/components/schemas/QuizzesGeneratedMcqComponent"
                               }
                             }
                           },
@@ -10371,6 +10500,20 @@
                               "Open Book",
                               "Closed Book"
                             ]
+                          },
+                          "AssociatedChapter": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number"
+                              },
+                              "documentId": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "Identifier": {
+                            "type": "string"
                           },
                           "createdAt": {
                             "type": "string",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-02-17T05:35:27.963Z"
+    "x-generation-date": "2025-03-03T02:38:25.310Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldIcon/index.jsx
+++ b/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldIcon/index.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { Flex } from "@strapi/design-system";
+import { Key } from "@strapi/icons";
+import styled from "styled-components";
+
+const IconBox = styled(Flex)`
+  /* Hard code color values */
+  /* to stay consistent between themes */
+  background-color: #f0f0ff; /* primary100 */
+  border: 1px solid #d9d8ff; /* primary200 */
+
+  svg > path {
+    fill: #4945ff; /* primary600 */
+  }
+`;
+
+const MCQGeneratorFieldIcon = () => {
+  return (
+    <IconBox
+      justifyContent="center"
+      alignItems="center"
+      width={7}
+      height={6}
+      hasRadius
+      aria-hidden
+    >
+      <Key/>
+    </IconBox>
+  );
+};
+
+export default MCQGeneratorFieldIcon;

--- a/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/index.jsx
+++ b/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/index.jsx
@@ -82,8 +82,6 @@ const Index = ({
     }
   };
 
-  // const saveButton = document.querySelector('button[type="button"]:has-text("Save")');
-
   return (
     <Field.Root
       name={name}

--- a/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/index.jsx
+++ b/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/index.jsx
@@ -64,10 +64,25 @@ const Index = ({
       onChange({
         target: { name, value: parsedResponse, type: attribute.type },
       });
+
+      setTimeout(() => {
+        document.querySelectorAll("button").forEach((button) => {
+          let span = button.querySelector("span");
+          if (span && span.textContent.trim() === "Save") {
+            button.removeAttribute("disabled"); // Enable the button
+            button.disabled = false;
+            button.click(); // Click it
+            console.log("Save button clicked");
+          }
+        });
+      }, 300);
+
     } catch (err) {
       throw new Error(`Error generating MCQ! status: ${err}`);
     }
   };
+
+  // const saveButton = document.querySelector('button[type="button"]:has-text("Save")');
 
   return (
     <Field.Root

--- a/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/index.jsx
+++ b/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/index.jsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect } from "react";
+import {Button, Field, Flex} from "@strapi/design-system";
+import { Textarea, Grid } from "@strapi/design-system";
+import useDebounce from "./useDebounce";
+import { unstable_useContentManagerContext as useContentManagerContext } from "@strapi/strapi/admin";
+import PropTypes from 'prop-types';
+
+
+// Component for raw QA field
+const Index = ({
+                 name,
+                 attribute,
+                 value = '',
+                 labelAction = null,
+                 label,
+                 disabled = false,
+                 error = null,
+                 required = true,
+                 hint = '',
+                 placeholder,
+                 onChange,
+               }) => {
+  const { form } = useContentManagerContext();
+  const { values } = form;
+
+  // change text to show API is being called
+  function showLoading() {
+    const loadingString = "Currently being generated...";
+
+    onChange({
+      target: { name, value: loadingString, type: attribute.type },
+    });
+  }
+
+  const createMCQ = async () => {
+    try {
+      showLoading();
+      console.log("Creating MCQ")
+      const response = await fetch(`/auto-content/create-mcq`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${JSON.parse(window.sessionStorage.jwtToken)}`,
+        },
+        body: JSON.stringify({
+          identifier: values.Identifier,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Error! status: ${response.status}`);
+      }
+      let parsedResponse = await response.json()
+
+      if ("error" in parsedResponse) {
+        parsedResponse = `Error generating MCQ: ${parsedResponse.error.message}`;
+      }
+      else if(parsedResponse.choices[0].message.content.trim().length === 0 && parsedResponse.choices[0].finish_reason === "length"){
+        parsedResponse = `Error generating MCQ: ran out of tokens. `;
+      } else {
+        parsedResponse =  parsedResponse.choices[0].message.content.trim();
+      }
+
+      onChange({
+        target: { name, value: parsedResponse, type: attribute.type },
+      });
+    } catch (err) {
+      throw new Error(`Error generating MCQ! status: ${err}`);
+    }
+  };
+
+  return (
+    <Field.Root
+      name={name}
+      id={name}
+      error={error}
+      hint={hint}
+      required={required}
+    >
+      <Flex direction="column" alignItems="stretch" gap={1}>
+        <Field.Label action={labelAction}>{name}</Field.Label>
+        <Textarea
+          placeholder='Press the button to generate a MCQ question based on the chapter.'
+          name="content"
+          value={value}
+          onChange={(e) =>
+            onChange({
+              target: { name, value: e.target.value, type: attribute.type },
+            })}
+        >
+          {value}
+        </Textarea>
+        <Field.Hint />
+        <Field.Error />
+      </Flex>
+      <Flex direction="column" alignItems="stretch" gap={1}>
+        <Button fullWidth onClick={() => createMCQ()}>
+          Create MCQ Question
+        </Button>
+      </Flex>
+    </Field.Root>
+  );
+}
+
+Index.propTypes = {
+  name: PropTypes.string.isRequired,
+  attribute: PropTypes.object.isRequired,
+  value: PropTypes.string,
+  labelAction: PropTypes.object,
+  label: PropTypes.string,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+  required: PropTypes.bool,
+  hint: PropTypes.string,
+  placeholder: PropTypes.string,
+};
+
+const MemoizedInput = React.memo(Index);
+
+export default MemoizedInput;

--- a/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/useDebounce.js
+++ b/src/plugins/auto-content/admin/src/components/MCQGeneratorField/MCQGeneratorFieldInput/useDebounce.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/plugins/auto-content/admin/src/index.js
+++ b/src/plugins/auto-content/admin/src/index.js
@@ -9,6 +9,7 @@ import KeyPhraseGeneratorIcon from "./components/KeyPhraseGenerator/KeyPhraseGen
 import SlugFieldIcon from "./components/SlugField/SlugFieldIcon";
 import PageSummaryFieldIcon from "./components/PageSummaryField/PageSummaryFieldIcon";
 import VolumeSummaryFieldIcon from "./components/VolumeSummaryField/VolumeSummaryFieldIcon";
+import MCQGeneratorFieldIcon from "./components/MCQGeneratorField/MCQGeneratorFieldIcon";
 
 const name = pluginPkg.strapi.name;
 
@@ -192,6 +193,28 @@ export default {
         components: {
           Input: async () =>
             import("./components/VolumeSummaryField/VolumeSummaryFieldInput"),
+        },
+        options: {
+          base: [],
+          advanced: [],
+        },
+      },
+      {
+        name: "mcqGenerator",
+        pluginId: "auto-content",
+        type: "text",
+        intlLabel: {
+          id: "mcqGenerator.mcqGenerator.label",
+          defaultMessage: "MCQ Generator",
+        },
+        intlDescription: {
+          id: "mcqGenerator.mcqGenerator.description",
+          defaultMessage: "Generate a multiple choice question using AI",
+        },
+        icon: MCQGeneratorFieldIcon,
+        components: {
+          Input: async () =>
+            import("./components/MCQGeneratorField/MCQGeneratorFieldInput"),
         },
         options: {
           base: [],

--- a/src/plugins/auto-content/server/controllers/create-mcq-controller.js
+++ b/src/plugins/auto-content/server/controllers/create-mcq-controller.js
@@ -1,0 +1,21 @@
+module.exports = ({ strapi }) => {
+  const mcqGeneratorService =
+    strapi.plugins["auto-content"].service("mcqGeneratorService");
+
+  const createMCQ = async (ctx) => {
+    const id = ctx.request.body.identifier;
+    if (id && id.length > 0) {
+      try {
+        return mcqGeneratorService.createMCQ(id);
+      } catch (err) {
+        console.log(err);
+        ctx.throw(500, err);
+      }
+    }
+    return ctx.throw(400, "Identifier is missing.");
+  };
+
+  return {
+    createMCQ,
+  };
+};

--- a/src/plugins/auto-content/server/controllers/index.js
+++ b/src/plugins/auto-content/server/controllers/index.js
@@ -6,5 +6,6 @@ module.exports = {
   transcriptGenerator: require("./fetch-transcript-controller"),
   keyPhraseGenerator: require("./keyphrase-extraction-controller"),
   pageSummaryField: require("./create-page-summary-controller"),
-  volumeSummaryField: require("./create-volume-summary-controller")
+  volumeSummaryField: require("./create-volume-summary-controller"),
+  mcqGeneratorField: require("./create-mcq-controller")
 };

--- a/src/plugins/auto-content/server/register.js
+++ b/src/plugins/auto-content/server/register.js
@@ -65,5 +65,14 @@ module.exports = ({ strapi }) => {
         isResizable: true,
       },
     },
+    {
+      name: "mcqGenerator",
+      plugin: "auto-content",
+      type: "text",
+      inputSize: {
+        default: 12,
+        isResizable: true,
+      },
+    },
   ]);
 };

--- a/src/plugins/auto-content/server/routes/index.js
+++ b/src/plugins/auto-content/server/routes/index.js
@@ -4,5 +4,6 @@ module.exports = {
   transcript: require("./transcript"),
   keyPhrase: require("./keyPhrase"),
   pageSummary: require("./pageSummary"),
-  volumeSummary: require("./volumeSummary")
+  volumeSummary: require("./volumeSummary"),
+  mcqGenerator: require("./mcqGenerator")
 };

--- a/src/plugins/auto-content/server/routes/mcqGenerator.js
+++ b/src/plugins/auto-content/server/routes/mcqGenerator.js
@@ -1,0 +1,12 @@
+module.exports = {
+  // accessible only from admin UI
+  type: "admin",
+  routes: [
+    {
+      method: "POST",
+      path: "/create-mcq",
+      handler: "mcqGeneratorField.createMCQ",
+      config: { policies: [] },
+    },
+  ],
+};

--- a/src/plugins/auto-content/server/services/index.js
+++ b/src/plugins/auto-content/server/services/index.js
@@ -8,5 +8,6 @@ module.exports = {
   fetchTranscriptService: require("./fetch-transcript-service"),
   keyPhraseService: require("./keyphrase-service"),
   pageSummaryService: require("./page-summary-service"),
-  volumeSummaryService: require("./volume-summary-service")
+  volumeSummaryService: require("./volume-summary-service"),
+  mcqGeneratorService: require("./mcq-service")
 };

--- a/src/plugins/auto-content/server/services/mcq-service.js
+++ b/src/plugins/auto-content/server/services/mcq-service.js
@@ -1,0 +1,132 @@
+"use strict";
+
+const fetch = require("node-fetch");
+
+module.exports = ({strapi}) => {
+  const createMCQ = async (Identifier) => {
+    let text = ""
+    let volume;
+    let pastQuestions
+    try{
+      const entry = await strapi.entityService.findMany('api::quiz.quiz', {
+        populate: {AssociatedChapter: true, Questions: true},
+        filters: {
+          Identifier: Identifier,
+        },
+      });
+      for(let question of entry[0].Questions){
+        if(question.__component === 'quizzes.generated-mcq' && question.GeneratedQuestion !== 'Currently being generated...'){
+          pastQuestions+=question.GeneratedQuestion + "\n"
+        }
+        else if (question.__component === 'quizzes.multiple-choice-question' && question.Question !== null){
+          pastQuestions+=question.GeneratedQuestion + "\n"
+        }
+      }
+      const chapter = await strapi.entityService.findMany('api::chapter.chapter', {
+        populate: {Pages: true, Volume: true},
+        filters: {
+          documentId: entry[0].AssociatedChapter.documentId,
+        },
+      });
+      volume = chapter[0].Volume
+      for(let page of chapter[0].Pages) {
+        const page = await strapi.entityService.findMany('api::page.page', {
+          populate: {Content: true},
+          filters: {
+            documentId: chapter[0].Pages[0].documentId,
+          },
+        });
+
+        for (let chunk of page[0].Content) {
+          text += chunk.CleanText
+
+        }
+
+      }
+    }
+    catch (error) {
+      console.log(error);
+    }
+    try {
+      // prompt is based on formatting from parse-gpt-mc notebook
+      const prompt = [
+        {
+        role: "user",
+        content: `
+        Objective: You are an expert educational content designer creating a multiple-choice question that aligns with the chapter's learning objectives while avoiding redundancy. The question must be one of the following types: recall, paraphrase, or inferential.
+        Inputs: You will be provided with the following inputs.
+        - Chapter text: The primary source for generating questions.
+        - Existing questions: Ensure your question is complementary and non-duplicative.
+        - Volume summary & description: A high-level overview of key themes and concepts to guide question design
+        Task guidelines:
+        Step 1: Content Analysis
+        - Extract 5-7 key concepts from the chapter, prioritizing themes, definitions, and cause-effect relationships emphasized in the Volume Summary.
+        - For inferential questions, identify 2-3 scenarios where students apply concepts in new contexts.
+        Step 2: Question Generation
+        - Recall: Test foundational facts and definitions (e.g., "What is the definition of X?").
+        - Paraphrase: Rephrase key ideas without directly quoting the textbook (e.g., "Which statement best describes X?").
+        - Inferential: Require students to apply knowledge to a novel situation.
+        - Only provide 1 correct answer choice and make the other incorrect.
+        Format Criteria:
+        - Ensure your output is in a MD format that follows the exact structure and keys as shown below but do NOT enclose it with \`\`\`MD\`\`\`:
+          - question: "The question goes here"
+            answers:
+            - answer: "a.\\tThe first answer"
+              correct: boolean if it's correct
+            - answer: "b.\\tThe second answer"
+              correct: boolean if it's correct
+            - answer: "c.\\tThe third answer"
+              correct: boolean if it's correct
+            - answer: "d.\\tThe fourth answer"
+              correct: boolean if it's correct
+        `
+      },
+        {
+          "role": "user",
+          "content": `
+          Inputs (Provided):
+          Chapter text:
+          [begin chapter text]
+          ${text}
+          [end chapter text]
+          Existing questions
+          ${pastQuestions}
+          Volume summary and description
+          Volume summary
+          ${volume.VolumeSummary}
+          Volume description
+          ${volume.Description}
+
+          Your directive:
+          - Generate a single multiple choice question by rigorously following the criteria listed above.
+          - Your response should be in the above format without any additional text or explanation.`
+        }
+      ];
+      const response = await fetch(
+        `https://api.openai.com/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${strapi
+              .plugin("auto-content")
+              .config("API_TOKEN")}`,
+          },
+          body: JSON.stringify({
+            model: "gpt-4o-2024-08-06",
+            messages: prompt,
+            temperature: 0.7,
+          }),
+        },
+      );
+      const res = await response.json();
+      return res;
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return {
+    createMCQ,
+  };
+};

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -97,6 +97,17 @@ export interface PageVideo extends Struct.ComponentSchema {
   };
 }
 
+export interface QuizzesGeneratedMcq extends Struct.ComponentSchema {
+  collectionName: 'components_quizzes_generated_mcqs';
+  info: {
+    displayName: 'GeneratedMCQ';
+  };
+  attributes: {
+    GeneratedQuestion: Schema.Attribute.Text &
+      Schema.Attribute.CustomField<'plugin::auto-content.mcqGenerator'>;
+  };
+}
+
 export interface QuizzesMultipleChoiceOption extends Struct.ComponentSchema {
   collectionName: 'components_quizzes_multiple_choice_options';
   info: {
@@ -131,6 +142,7 @@ declare module '@strapi/strapi' {
       'page.chunk': PageChunk;
       'page.plain-chunk': PagePlainChunk;
       'page.video': PageVideo;
+      'quizzes.generated-mcq': QuizzesGeneratedMcq;
       'quizzes.multiple-choice-option': QuizzesMultipleChoiceOption;
       'quizzes.multiple-choice-question': QuizzesMultipleChoiceQuestion;
     }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -558,16 +558,21 @@ export interface ApiQuizQuiz extends Struct.CollectionTypeSchema {
     draftAndPublish: true;
   };
   attributes: {
+    AssociatedChapter: Schema.Attribute.Relation<
+      'oneToOne',
+      'api::chapter.chapter'
+    >;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    Identifier: Schema.Attribute.UID;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::quiz.quiz'> &
       Schema.Attribute.Private;
     PreviousPage: Schema.Attribute.Relation<'oneToOne', 'api::page.page'>;
     publishedAt: Schema.Attribute.DateTime;
     Questions: Schema.Attribute.DynamicZone<
-      ['quizzes.multiple-choice-question']
+      ['quizzes.multiple-choice-question', 'quizzes.generated-mcq']
     >;
     QuizType: Schema.Attribute.Enumeration<['Open Book', 'Closed Book']> &
       Schema.Attribute.Required &


### PR DESCRIPTION
<!-- 
PR Title format: 
<type>(scope): <short description>

Types: 
build - Changes that affect the build system or external dependencies (dependencies update)
ci - Changes to our github configuration files and scripts (such as directory .github/workflows)
docs - Documentation only changes
feat - A new feature
fix - A bug fix
style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

Scope: Part of the project that was touched (i.e. CKEditor, Auto-Content, Github Publish)
-->
## Description
<!-- 
Provide an in depth description of the edits that were made and purpose. Include screenshots when appropriate]
-->
Provides a button that can be used to generate multiple choice questions that can automatically be added to the MD.

## Additional Information
<!-- 
Provide any additional information here. 
-->
- It takes into consideration the Chapter content, past questions, volume summary, and volume description. 
- Currently, it is fed all of the clean text, including the plain chunks. 
- Any quiz that utilizes the feature will need to be saved with every question in order to allow the new question to be added to the "Past Questions" information for the AI. 
- Any quiz that utilizes the feature will require a Chapter relation that will be providing the content to the text. 