### PR TITLE
Add acquireTimeout and other pool configs

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -28,7 +28,13 @@ module.exports = ({ env }) => {
         pool: {
           min: env.int("DATABASE_POOL_MIN"),
           max: env.int("DATABASE_POOL_MAX"),
-          idleTimeoutMillis: 3000,
+          acquireTimeoutMillis: 300000,
+          createTimeoutMillis: 300000,
+          destroyTimeoutMillis: 50000,
+          idleTimeoutMillis: 300000,
+          reapIntervalMillis: 10000,
+          createRetryIntervalMillis: 2000,
+          propagateCreateError: false,
         },
       },
     };


### PR DESCRIPTION
From: https://community.render.com/t/connection-error-connection-ended-unexpectedly/4762/2

shoutout to render support for the suggestion: Strapi v4, postgres, Error "Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?" · Issue #11860 · strapi/strapi · GitHub

production: {
    client: "pg",
    connection: DATABASE_URL,
    migrations: {
      directory: "./migrations",
      tableName: "knex_migrations",
    },
    pool: {
      min: 0,
      max: 7,
      acquireTimeoutMillis: 300000,
      createTimeoutMillis: 300000,
      destroyTimeoutMillis: 50000,
      idleTimeoutMillis: 300000,
      reapIntervalMillis: 10000,
      createRetryIntervalMillis: 2000,
      propagateCreateError: false,
    },
    acquireConnectionTimeout: 60000,
  },

<!-- 
PR Title format: 
<type>(scope): <short description>

Types: 
build - Changes that affect the build system or external dependencies (dependencies update)
ci - Changes to our github configuration files and scripts (such as directory .github/workflows)
docs - Documentation only changes
feat - A new feature
fix - A bug fix
style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

Scope: Part of the project that was touched (i.e. CKEditor, Auto-Content, Github Publish)
-->
## Description
<!-- 
Provide an in depth description of the edits that were made and purpose. Include screenshots when appropriate]
-->

## Additional Information
<!-- 
Provide any additional information here. 
-->
