### PR TITLE
feat(Auto-Content): Throws alerts without refreshing page when YouTube transcript fails

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "5.14.0",
-	"lastUpdateCheck": 1749012721624,
-	"lastNotification": 1748525762202
+	"latest": "5.16.1",
+	"lastUpdateCheck": 1751304254283,
+	"lastNotification": 1751304254275
 }

--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "5.16.1",
-	"lastUpdateCheck": 1751304254283,
+	"latest": "5.17.0",
+	"lastUpdateCheck": 1751490258396,
 	"lastNotification": 1751304254275
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-04T04:54:10.111Z"
+    "x-generation-date": "2025-06-30T20:30:44.403Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-30T20:30:44.403Z"
+    "x-generation-date": "2025-07-02T22:06:51.598Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/src/plugins/auto-content/admin/src/components/ContentGenerator/ContentGeneratorInput/index.jsx
+++ b/src/plugins/auto-content/admin/src/components/ContentGenerator/ContentGeneratorInput/index.jsx
@@ -211,11 +211,20 @@ const Index = ({
 
   const fetchTranscript = async () => {
     try {
-      const payload = JSON.stringify({
+      let payload = {
         url: `${debouncedVideoFieldValue["url"]}`,
         startTime: `${debouncedVideoFieldValue["startTime"]}`,
         endTime: `${debouncedVideoFieldValue["endTime"]}`,
-      });
+      };
+
+      console.log(payload.url, typeof payload.url)
+
+      if (payload.url === "undefined" || payload.url === "null" || payload.url === "") {
+        alert("Missing URL for video")
+        return ""
+      }
+
+      payload = JSON.stringify(payload)
       // fetch transcript service
       const response = await fetch(`/auto-content/fetch-transcript`, {
         method: "POST",
@@ -225,6 +234,12 @@ const Index = ({
         },
         body: payload,
       });
+
+      if(response.status === 400){
+        alert((await response.json()).error.message)
+        return ""
+      }
+
       let fetchedTranscript;
 
       try {

--- a/src/plugins/auto-content/admin/src/components/ContentGenerator/ContentGeneratorInput/index.jsx
+++ b/src/plugins/auto-content/admin/src/components/ContentGenerator/ContentGeneratorInput/index.jsx
@@ -142,6 +142,10 @@ const Index = ({
       // create clean text to feed into QA generation
       const cleanTextFeed = await getTargetText();
 
+      if(!cleanTextFeed){
+        return
+      }
+
       const response = await fetch(`/auto-content/generate-question`, {
         method: "POST",
         headers: {
@@ -221,23 +225,23 @@ const Index = ({
         },
         body: payload,
       });
-
-      if (!response.ok) {
-        throw new Error(`Error! status: ${response.status}`);
-      }
-
       let fetchedTranscript;
 
       try {
         fetchedTranscript = await response.text();
+
+        if(fetchedTranscript.includes("Error: ")){
+          alert(fetchedTranscript)
+        }
+        else{
+          return fetchedTranscript;
+        }
       } catch (error) {
-        console.error("Error fetching transcript:", error);
-        fetchedTranscript = "Error fetching transcript";
+        console.log(error)
       }
 
-      return fetchedTranscript;
     } catch (err) {
-      console.log(err);
+      console.log(error)
     }
   };
 

--- a/src/plugins/auto-content/admin/src/components/KeyPhraseGenerator/KeyPhraseGeneratorInput/index.jsx
+++ b/src/plugins/auto-content/admin/src/components/KeyPhraseGenerator/KeyPhraseGeneratorInput/index.jsx
@@ -105,6 +105,10 @@ const Index = ({
       showLoading();
       // create clean text to feed into QA generation
       const cleanTextFeed = await getTargetText();
+      if(!cleanTextFeed){
+        return
+      }
+
       const response = await fetch(`/auto-content/extract-keyphrase`, {
         method: "POST",
         headers: {
@@ -186,15 +190,19 @@ const Index = ({
 
       try {
         fetchedTranscript = await response.text();
+
+        if(fetchedTranscript.includes("Error: ")){
+          alert(fetchedTranscript)
+        }
+        else{
+          return fetchedTranscript;
+        }
       } catch (error) {
-        console.error("Error fetching transcript:", error);
-        fetchedTranscript = "Error fetching transcript";
-        throw new Error(`Error fetching transcript! status: ${error}`);
+        console.log(error)
       }
 
-      return fetchedTranscript;
     } catch (err) {
-      console.log(err);
+      console.log(error)
     }
   };
 

--- a/src/plugins/auto-content/server/controllers/fetch-transcript-controller.js
+++ b/src/plugins/auto-content/server/controllers/fetch-transcript-controller.js
@@ -10,17 +10,7 @@ module.exports = ({ strapi }) => {
     const url = ctx.request.body.url;
     const startTime = ctx.request.body.startTime;
     const endTime = ctx.request.body.endTime;
-    console.log("URL: " + url, typeof url)
-    if (url !== "undefined" && url !== "null" && url !== "") {
-      try {
-        return fetchTranscriptService.getTranscript(url, startTime, endTime);
-      } catch (err) {
-        console.log(err)
-      }
-    }
-    else{
-      return "Error: Blank URL provided. Please input URL"
-    }
+    return fetchTranscriptService.getTranscript(url, startTime, endTime, ctx);
   };
 
   return {

--- a/src/plugins/auto-content/server/controllers/fetch-transcript-controller.js
+++ b/src/plugins/auto-content/server/controllers/fetch-transcript-controller.js
@@ -1,3 +1,6 @@
+const { errors } = require("@strapi/utils");
+const { ApplicationError } = errors;
+
 module.exports = ({ strapi }) => {
   const fetchTranscriptService = strapi.plugins["auto-content"].service(
     "fetchTranscriptService",
@@ -7,17 +10,17 @@ module.exports = ({ strapi }) => {
     const url = ctx.request.body.url;
     const startTime = ctx.request.body.startTime;
     const endTime = ctx.request.body.endTime;
-
-    if (url) {
+    console.log("URL: " + url, typeof url)
+    if (url !== "undefined" && url !== "null" && url !== "") {
       try {
         return fetchTranscriptService.getTranscript(url, startTime, endTime);
       } catch (err) {
-        console.log(err);
-        ctx.throw(500, err);
+        console.log(err)
       }
     }
-
-    return ctx.throw(400, "URL is missing.");
+    else{
+      return "Error: Blank URL provided. Please input URL"
+    }
   };
 
   return {

--- a/src/plugins/auto-content/server/services/fetch-transcript-service.js
+++ b/src/plugins/auto-content/server/services/fetch-transcript-service.js
@@ -1,11 +1,9 @@
 "use strict";
 
 const fetch = require("node-fetch");
-const { errors } = require("@strapi/utils");
-const { ApplicationError } = errors;
 
 module.exports = ({ strapi }) => {
-  const getTranscript = async (url, start, end) => {
+  const getTranscript = async (url, start, end, ctx) => {
     const start_num = parseInt(start);
     const end_num = parseInt(end);
 
@@ -25,11 +23,11 @@ module.exports = ({ strapi }) => {
         },
       );
       if(response.status === 500){
-        return("Error: Problem obtaining transcript. Contact LearLab for API update.")
+        return ctx.badRequest('Problem obtaining transcript. Contact LearLab for API update.' );
       }
 
       else if(response.status === 422){
-        return("Error: Invalid input for the URL.")
+        return ctx.badRequest('Invalid input for the URL.');
       }
       else{
         try{
@@ -37,7 +35,7 @@ module.exports = ({ strapi }) => {
           return result.transcript;
         }
         catch(e){
-          return(`Error: Couldn't parse API result. Contact for API update: ${e}`)
+          return ctx.badRequest(`Couldn't parse API result. Contact LearLab for API update: ${e}`);
         }
       }
 

--- a/src/plugins/auto-content/server/services/fetch-transcript-service.js
+++ b/src/plugins/auto-content/server/services/fetch-transcript-service.js
@@ -9,7 +9,6 @@ module.exports = ({ strapi }) => {
     const start_num = parseInt(start);
     const end_num = parseInt(end);
 
-    try {
       const response = await fetch(
         `https://itell-api.learlab.vanderbilt.edu/generate/transcript`,
         {
@@ -25,13 +24,23 @@ module.exports = ({ strapi }) => {
           }),
         },
       );
-      const result = await response.json();
-      return result.transcript;
-    } catch (error) {
-      throw new ApplicationError("Failed to generate transcript", {
-        foo: "bar",
-      });
-    }
+      if(response.status === 500){
+        return("Error: Problem obtaining transcript. Contact LearLab for API update.")
+      }
+
+      else if(response.status === 422){
+        return("Error: Invalid input for the URL.")
+      }
+      else{
+        try{
+          const result = await response.json();
+          return result.transcript;
+        }
+        catch(e){
+          return(`Error: Couldn't parse API result. Contact for API update: ${e}`)
+        }
+      }
+
   };
 
   return {


### PR DESCRIPTION
<!-- 
PR Title format: 
<type>(scope): <short description>

Types: 
build - Changes that affect the build system or external dependencies (dependencies update)
ci - Changes to our github configuration files and scripts (such as directory .github/workflows)
docs - Documentation only changes
feat - A new feature
fix - A bug fix
style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

Scope: Part of the project that was touched (i.e. CKEditor, Auto-Content, Github Publish)
-->
## Description
<!-- 
Provide an in depth description of the edits that were made and purpose. Include screenshots when appropriate]
-->
Created a system that gives useful error messages regarding what's wrong with the transcript description upon attempt to get keyphrases or generating a Q/A for the Video Chunks. 
<img width="634" alt="Screenshot 2025-06-30 at 3 36 50 PM" src="https://github.com/user-attachments/assets/0d271f0b-c879-4737-af49-70a50fecbcb3" />
<img width="642" alt="Screenshot 2025-06-30 at 3 36 39 PM" src="https://github.com/user-attachments/assets/23f4907e-0dff-48b0-a0ab-749e7a66639b" />
<img width="649" alt="Screenshot 2025-06-30 at 3 36 32 PM" src="https://github.com/user-attachments/assets/326a8b55-acec-46e6-a9bb-fcb4b6324545" />



## Additional Information
<!-- 
Provide any additional information here. 
-->
Attempted to do this via an application error, but it ends up completely refreshing the page which results in losing progress. Used built in alerts instead. 