### PR TITLE
fix(Quizzes): Make IsCorrect null by default in Multiple Choice Questions

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "5.15.0",
-	"lastUpdateCheck": 1749575325017,
-	"lastNotification": 1749575306299
+	"latest": "5.18.0",
+	"lastUpdateCheck": 1752530931186,
+	"lastNotification": 1752530931179
 }

--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "5.14.0",
-	"lastUpdateCheck": 1749012721624,
-	"lastNotification": 1748525762202
+	"latest": "5.15.0",
+	"lastUpdateCheck": 1749575325017,
+	"lastNotification": 1749575306299
 }

--- a/src/components/quizzes/multiple-choice-option.json
+++ b/src/components/quizzes/multiple-choice-option.json
@@ -13,7 +13,7 @@
     },
     "IsCorrect": {
       "type": "boolean",
-      "default": false,
+      "default": null,
       "required": true
     }
   }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-04T04:54:10.111Z"
+    "x-generation-date": "2025-06-10T18:54:06.178Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-10T18:54:06.178Z"
+    "x-generation-date": "2025-07-14T22:48:58.838Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -99,9 +99,7 @@ export interface QuizzesMultipleChoiceOption extends Struct.ComponentSchema {
     icon: 'bulletList';
   };
   attributes: {
-    IsCorrect: Schema.Attribute.Boolean &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<false>;
+    IsCorrect: Schema.Attribute.Boolean & Schema.Attribute.Required;
     Text: Schema.Attribute.Text & Schema.Attribute.Required;
   };
 }


### PR DESCRIPTION
## Description

Make the `IsCorrect` boolean `null` by default. This is a required field, so marking it `null` forces the instructor to mark each answer choice as either wrong (false) or correct (true). 

<img width="256" alt="image" src="https://github.com/user-attachments/assets/2718ec8a-99bd-40ae-a3e5-bae07240e753" />

In MCQs, we were having an issue where no answer choice was marked as the correct answer in Strapi, meaning that regardless of the answer choice that was picked by a student, it would always be false. Each answer choice has a mandatory `IsCorrect` field that determines if it is the correct answer to the question. 

## Additional Information

Ideally, there should always be exactly 1 correct answer. This does NOT enforce the rule that there should be exactly 1 correct answer, but it does minimize the risk that there will be none, since an instructor is unlikely to mark every answer as false with manual marking. 